### PR TITLE
Corrected relative and external links

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,16 +9,16 @@ The original idea behind the BrainGrid Project is to develop a toolkit/software 
 - It provides a programming interface to minimize code changes needed to port the simulation to single or multiple GPUs. In effect, we've already optimized the simulator for GPUs (this addresses the "high performance" aspect).
 - We provide a (Java based) Workbench that allows the investigator to download, build, and run the simulator; the Workbench captures all software and data provenance information, so that later the investigator can compare different results generated at different times and see how they differ in terms of not only their input parameters but also their simulator versions. This helps one to determine whether two simulations are comparable, whether one or more are invalid due to simulator bugs, etc. (This also connects to the idea of "high quality".)
 
-### [BrainGrid](braingrid_index)
+### [BrainGrid](https://UWB-Biocomputing.github.io/BrainGrid/)
 
 ### [Workbench](https://UWB-Biocomputing.github.io/WorkBench/)
 
 
 ### Examples [under construction]
 
-### [Lab Publication](lab-publication) 
+### [Lab Publication](https://UWB-Biocomputing.github.io/BrainGrid/lab-publication) 
 
-### [Acknowledgements](acknowledgements)
+### [Acknowledgements](https://UWB-Biocomputing.github.io/BrainGrid/acknowledgements)
 
 ---------
 ### Multiple simulation architectures:
@@ -35,7 +35,7 @@ The original idea behind the BrainGrid Project is to develop a toolkit/software 
 
 ### BrainGrid Resources:
 
-- [BrainGrid Forum]([https://groups.google.com/forum/#!forum/uwb-braingrid](https://groups.google.com/forum/#!forum/uwb-braingrid)): A place where BrainGridders can communicate and collaborate. Click the button "Apply to join this group" to be a BrainGridder.
+- [BrainGrid Forum](https://groups.google.com/forum/#!forum/uwb-braingrid): A place where BrainGridders can communicate and collaborate. Click the button "Apply to join this group" to be a BrainGridder.
 - [Git Crash Course](https://github.com/UWB-Biocomputing/BrainGrid/wiki/Git-Crash-Course)
 - [Linux Crash Course](https://github.com/UWB-Biocomputing/BrainGrid/wiki/Linux-Crash-Course)
 


### PR DESCRIPTION
Because most of the BrainGrid-specific documentation was using relative references to files, the fully qualified URL needs to be specified.
Additionally, the link to the Google Group forum for the research team had an extra link nested, so the original link on the website was broken (this has been fixed).